### PR TITLE
`UbersmithException` returns the original `code` and `message` given by  the API

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -77,7 +77,13 @@ class UbersmithIWebTest(unittest.TestCase):
         ubersmith_api = ubersmith_client.api.init(self.url, self.username, self.password)
 
         self.expect_a_ubersmith_call(request_mock, method="client.miss", data=data)
-        assert_that(calling(ubersmith_api.client.miss), raises(ubersmith_client.exceptions.UbersmithException))
+
+        with self.assertRaises(ubersmith_client.exceptions.UbersmithException) as cm:
+            ubersmith_api.client.miss()
+
+        catched_exception = cm.exception
+        assert_that(catched_exception.code, equal_to(1))
+        assert_that(catched_exception.message, equal_to('invalid method specified: client.miss'))
 
     @requests_mock.mock()
     def test_api_raises_exception_for_invalid_status_code(self, request_mock):

--- a/ubersmith_client/api.py
+++ b/ubersmith_client/api.py
@@ -69,8 +69,8 @@ class UbersmithRequest(object):
         response_json = response.json()
         if not response_json['status']:
             raise UbersmithException(
-                500,
-                "error {0}, {1}".format(response_json['error_code'], response_json['error_message'])
+                response_json['error_code'],
+                response_json['error_message']
             )
 
         return response.json()["data"]


### PR DESCRIPTION
Instead of having an exception being:

``` python
   code=500
   message='error {error_code}, {error_message}'
```

We now have:

``` python
   code={error_code}
   message={error_message}
```
