### PR TITLE
cast 'timeout' to float

### DIFF
--- a/ubersmith_client/ubersmith_api.py
+++ b/ubersmith_client/ubersmith_api.py
@@ -19,7 +19,7 @@ class UbersmithApi(object):
         self.url = url
         self.user = user
         self.password = password
-        self.timeout = timeout
+        self.timeout = float(timeout)
         self.ubersmith_request = UbersmithRequestGet if use_http_get else UbersmithRequestPost
 
     def __getattr__(self, module):


### PR DESCRIPTION
The 'timeout' value is often given as an integer, but the lib expects a float.
This casts the 'timeout' parameter as a float so callers do not have to bother.
